### PR TITLE
Fix #59, support SQLite3::SQLite3 target name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,10 @@ build*/
 *.pyc
 
 .vscode
+.clwb/
 
 .DS_STORE
 CMakeUserPresets.json
 
 bazel-*
+tests/bcr-consumer/MODULE.bazel.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.31)
 
-
 set(sl3_MAJOR_VERSION 1)
 set(sl3_MINOR_VERSION 3)
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ bazel_dep(name = "libsl3")
 
 To build libsl3 without any dependencies, run
 
-    cmake -S . -B build -DBUILD_TESTING=OFF -Dsl3_USE_INTERNAL_SQLITE3=ON -Dsl3_USE_COMMON_COMPILER_WARNINGS=OFF
+    cmake -S . -B build -Dsl3_BUILD_TESTING=OFF -Dsl3_USE_INTERNAL_SQLITE3=ON -Dsl3_USE_COMMON_COMPILER_WARNINGS=OFF
 
 This will build libsl3 with the internal sqlite distribution.
 The used sqlite version is documented in the patch level part of the actual libsl3 version.
 
 For using sqlite from the system, run
 
-    cmake -S . -B build -DBUILD_TESTING=OFF -Dsl3_USE_COMMON_COMPILER_WARNINGS=OFF
+    cmake -S . -B build -Dsl3_BUILD_TESTING=OFF -Dsl3_USE_COMMON_COMPILER_WARNINGS=OFF
 
 For more information about how to consume and build the library, visit [the documentation](https://a4z.github.io/libsl3/#Installation).
 

--- a/TestCMakeVersion.sh
+++ b/TestCMakeVersion.sh
@@ -1,0 +1,32 @@
+
+VERSION=$1
+
+if [ -z "$VERSION" ]; then
+  echo "usage: $0 <cmake-version>"
+  echo "  e.g. $0 3.31   or   $0 4.4"
+  exit 1
+fi
+
+if ! command -v uvx > /dev/null 2>&1; then
+  echo "uvx not found, install uv: https://docs.astral.sh/uv/getting-started/installation/"
+  exit 1
+fi
+
+shopt -s expand_aliases 2>/dev/null   # needed for bash, no-op/harmless in zsh
+alias cmake="uvx --from 'cmake==$VERSION.*' cmake"
+
+BUILD_FOLDER=build/tmp/test-cmake-$VERSION
+
+rm -rf $BUILD_FOLDER
+
+cmake -G "Ninja Multi-Config" -B $BUILD_FOLDER -S . \
+-DCMAKE_MODULE_PATH=cmake \
+-DCMAKE_PROJECT_INCLUDE=project-setup \
+-DCMAKE_TOOLCHAIN_FILE=toolchain/router \
+-DTOOLCHAIN_INCLUDES=toolchain/fetch-dependencies \
+-Dsl3_USE_INTERNAL_SQLITE3=OFF \
+--fresh
+
+cmake --build $BUILD_FOLDER
+
+cmake --build $BUILD_FOLDER --target test --parallel

--- a/cmake/lib/find_sqlite.cmake
+++ b/cmake/lib/find_sqlite.cmake
@@ -53,10 +53,13 @@ else(sl3_USE_INTERNAL_SQLITE3)
     set(SQLITE_LINK_NAME unofficial::sqlite3::sqlite3)
   else()
     find_package(SQLite3 REQUIRED)
-    set(SQLITE_LINK_NAME SQLite::SQLite3)
+    if(TARGET SQLite3::SQLite3)
+      set(SQLITE_LINK_NAME SQLite3::SQLite3)
+    else() # CMake < 4.3
+      set(SQLITE_LINK_NAME SQLite::SQLite3)
+    endif()
   endif()
 endif(sl3_USE_INTERNAL_SQLITE3)
 
 # print_variable(SQLite3_INCLUDE_DIR)
 # print_variable(SQLite3_LIBRARY)
-

--- a/cmake/lib/sl3Config.cmake.in
+++ b/cmake/lib/sl3Config.cmake.in
@@ -4,8 +4,9 @@
 include(CMakeFindDependencyMacro)
 
 set(_sl3_sqlite_link_target "@SQLITE_LINK_NAME@")
-if(_sl3_sqlite_link_target STREQUAL "SQLite::SQLite3")
-  find_dependency(SQLite3 REQUIRED)
+if(_sl3_sqlite_link_target MATCHES "^SQLite3?::SQLite3$")
+  # SQLite3::SQLite3 since CMake 4.3, SQLite::SQLite3 before
+  find_dependency(SQLite3)
 elseif(_sl3_sqlite_link_target STREQUAL "unofficial::sqlite3::sqlite3")
   find_dependency(unofficial-sqlite3 CONFIG REQUIRED)
 endif()

--- a/cmake/project-setup.cmake
+++ b/cmake/project-setup.cmake
@@ -17,6 +17,7 @@ if(PROJECT_IS_TOP_LEVEL)
     option(sl3_BUILD_TESTING "Build the tests" ${BUILD_TESTING})
 endif()
 
+message(STATUS "Using CMake ${CMAKE_VERSION} (${CMAKE_COMMAND})")
 
 if(DEFINED ACTIVE_PRESET_NAME)
   message(STATUS "--- Running preset : ${ACTIVE_PRESET_NAME}")

--- a/doc/doc.dox
+++ b/doc/doc.dox
@@ -54,7 +54,7 @@ FetchContent_Declare(
   GIT_TAG        main
   OVERRIDE_FIND_PACKAGE
 )
-SET(BUILD_TESTING OFF)
+SET(sl3_BUILD_TESTING OFF)
 SET(sl3_USE_INTERNAL_SQLITE3 ON)
 SET(sl3_USE_COMMON_COMPILER_WARNINGS OFF)
 
@@ -408,23 +408,3 @@ Running this program, the output will be
 \endcode
 
 */
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Use the new target name, alias the old one for CMake < 4.3.

Add TestCMakeVersion.sh to build and test with a given CMake version.